### PR TITLE
Add variable expansion to environment and args

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,6 +70,7 @@ $(DIR_STG_INIT)/$(DIR_ET)/sbin/init: \
 		go.mod \
 		$(shell find cmd/initial -type f -path '*.go' ! -path '*_test.go') \
 		$(shell find pkg -type f -path '*.go' ! -path '*_test.go') \
+		$(shell find third_party -type f -path '*.go' ! -path '*_test.go') \
 		| $(HAS_IMAGE_LOCAL) $(VAR_DIR_ET) $(DIR_STG_INIT)/$(DIR_ET)/sbin/
 	@docker run --rm -t \
 		-v $(DIR_ROOT):/code \
@@ -163,6 +164,8 @@ $(DIR_RELEASE)/easyto-$(VERSION)-$(OS)-$(ARCH).tar.gz: \
 		-f $(DIR_ROOT)/$(DIR_RELEASE)/easyto-$(VERSION)-$(OS)-$(ARCH).tar.gz assets bin packer
 
 test:
+	go vet -v ./third_party/...
+	go test -v ./third_party/...
 	go vet -v ./...
 	go test -v ./...
 

--- a/pkg/initial/initial/initial_test.go
+++ b/pkg/initial/initial/initial_test.go
@@ -482,6 +482,122 @@ func Test_resolveAllEnvs(t *testing.T) {
 			},
 			err: nil,
 		},
+		{
+			description: "Expand variables within values",
+			env: vmspec.NameValueSource{
+				{
+					Name:  "ENV",
+					Value: "value",
+				},
+				{
+					Name:  "EXPAND_ENV",
+					Value: "$(ENV)",
+				},
+				{
+					Name:  "ESCAPED",
+					Value: "$$(ENV)",
+				},
+				{
+					Name:  "NOT_FOUND",
+					Value: "$(NOT_FOUND)",
+				},
+				{
+					Name:  "NO_EXPAND_EXPANDED",
+					Value: "$(EXPAND_ENV)",
+				},
+				{
+					Name:  "EXPAND_ASM",
+					Value: "$(ASM)",
+				},
+				{
+					Name:  "EXPAND_S3",
+					Value: "$(S3)",
+				},
+				{
+					Name:  "EXPAND_SSM",
+					Value: "$(SSM)",
+				},
+				{
+					Name:  "EXPAND_MULTIPLE",
+					Value: "ENV: $(ENV), ASM: $(ASM), S3: $(S3), SSM: $(SSM)",
+				},
+			},
+			envFrom: vmspec.EnvFromSource{
+				{
+					SecretsManager: &vmspec.SecretsManagerEnvSource{
+						Base64Encode: true,
+						SecretID:     "secret-id",
+						Name:         "ASM",
+					},
+				},
+				{
+					S3: &vmspec.S3EnvSource{
+						Base64Encode: true,
+						Bucket:       "thebucket",
+						Key:          "/aaaaa",
+						Name:         "S3",
+					},
+				},
+				{
+					SSM: &vmspec.SSMEnvSource{
+						Base64Encode: true,
+						Path:         "/bbbbb",
+						Name:         "SSM",
+					},
+				},
+			},
+			result: vmspec.NameValueSource{
+				{
+					Name:  "ENV",
+					Value: "value",
+				},
+				{
+					Name:  "EXPAND_ENV",
+					Value: "value",
+				},
+				{
+					Name:  "ESCAPED",
+					Value: "$(ENV)",
+				},
+				{
+					Name:  "NOT_FOUND",
+					Value: "$(NOT_FOUND)",
+				},
+				{
+					Name:  "NO_EXPAND_EXPANDED",
+					Value: "$(ENV)",
+				},
+				{
+					Name:  "EXPAND_ASM",
+					Value: "VHdvIGJlZm9yZSBuYXJyb3cgbm90IHJlbGllZCBob3cgZXhjZXB0IG1vbWVudCBteXNlbGY=",
+				},
+				{
+					Name:  "EXPAND_S3",
+					Value: "SGFkIGRlbm90aW5nIHByb3Blcmx5IGpvaW50dXJlIHlvdSBvY2Nhc2lvbiBkaXJlY3RseSByYWlsbGVyeQ==",
+				},
+				{
+					Name:  "EXPAND_SSM",
+					Value: "T2NjYXNpb25hbCBtaWRkbGV0b25zIGV2ZXJ5dGhpbmcgc28gdG8=",
+				},
+				{
+					Name:  "EXPAND_MULTIPLE",
+					Value: "ENV: value, ASM: VHdvIGJlZm9yZSBuYXJyb3cgbm90IHJlbGllZCBob3cgZXhjZXB0IG1vbWVudCBteXNlbGY=, S3: SGFkIGRlbm90aW5nIHByb3Blcmx5IGpvaW50dXJlIHlvdSBvY2Nhc2lvbiBkaXJlY3RseSByYWlsbGVyeQ==, SSM: T2NjYXNpb25hbCBtaWRkbGV0b25zIGV2ZXJ5dGhpbmcgc28gdG8=",
+				},
+				{
+					Name:  "ASM",
+					Value: "VHdvIGJlZm9yZSBuYXJyb3cgbm90IHJlbGllZCBob3cgZXhjZXB0IG1vbWVudCBteXNlbGY=",
+				},
+				{
+					Name:  "S3",
+					Value: "SGFkIGRlbm90aW5nIHByb3Blcmx5IGpvaW50dXJlIHlvdSBvY2Nhc2lvbiBkaXJlY3RseSByYWlsbGVyeQ==",
+				},
+				{
+					Name:  "SSM",
+					Value: "T2NjYXNpb25hbCBtaWRkbGV0b25zIGV2ZXJ5dGhpbmcgc28gdG8=",
+				},
+			},
+			err: nil,
+		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.description, func(t *testing.T) {

--- a/pkg/initial/vmspec/vmspec.go
+++ b/pkg/initial/vmspec/vmspec.go
@@ -114,6 +114,15 @@ func (n NameValueSource) Find(key string) (string, int) {
 	return "", -1
 }
 
+// ToMap converts a NameValueSource to a map[string]string.
+func (n NameValueSource) ToMap() map[string]string {
+	m := map[string]string{}
+	for _, item := range n {
+		m[item.Name] = item.Value
+	}
+	return m
+}
+
 type nameValueTransformer struct{}
 
 // Transformer merges NameValueSource types. Values from src override values from dst if

--- a/third_party/forked/golang/LICENSE
+++ b/third_party/forked/golang/LICENSE
@@ -1,0 +1,27 @@
+Copyright (c) 2009 The Go Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/third_party/forked/golang/PATENTS
+++ b/third_party/forked/golang/PATENTS
@@ -1,0 +1,22 @@
+Additional IP Rights Grant (Patents)
+
+"This implementation" means the copyrightable works distributed by
+Google as part of the Go project.
+
+Google hereby grants to You a perpetual, worldwide, non-exclusive,
+no-charge, royalty-free, irrevocable (except as stated in this section)
+patent license to make, have made, use, offer to sell, sell, import,
+transfer and otherwise run, modify and propagate the contents of this
+implementation of Go, where such license applies only to those patent
+claims, both currently owned or controlled by Google and acquired in
+the future, licensable by Google that are necessarily infringed by this
+implementation of Go.  This grant does not include claims that would be
+infringed only as a consequence of further modification of this
+implementation.  If you or your agent or exclusive licensee institute or
+order or agree to the institution of patent litigation against any
+entity (including a cross-claim or counterclaim in a lawsuit) alleging
+that this implementation of Go or any code incorporated within this
+implementation of Go constitutes direct or contributory patent
+infringement, or inducement of patent infringement, then any patent
+rights granted to you under this License for this implementation of Go
+shall terminate as of the date such litigation is filed.

--- a/third_party/forked/golang/expansion/README.md
+++ b/third_party/forked/golang/expansion/README.md
@@ -1,0 +1,3 @@
+# expansion
+
+This package is forked from k8s.io/kubernetes, which is in turn forked from the os package in go.googlesource.com/go.

--- a/third_party/forked/golang/expansion/expand.go
+++ b/third_party/forked/golang/expansion/expand.go
@@ -1,0 +1,102 @@
+package expansion
+
+import (
+	"bytes"
+)
+
+const (
+	operator        = '$'
+	referenceOpener = '('
+	referenceCloser = ')'
+)
+
+// syntaxWrap returns the input string wrapped by the expansion syntax.
+func syntaxWrap(input string) string {
+	return string(operator) + string(referenceOpener) + input + string(referenceCloser)
+}
+
+// MappingFuncFor returns a mapping function for use with Expand that
+// implements the expansion semantics defined in the expansion spec; it
+// returns the input string wrapped in the expansion syntax if no mapping
+// for the input is found.
+func MappingFuncFor(context ...map[string]string) func(string) string {
+	return func(input string) string {
+		for _, vars := range context {
+			val, ok := vars[input]
+			if ok {
+				return val
+			}
+		}
+
+		return syntaxWrap(input)
+	}
+}
+
+// Expand replaces variable references in the input string according to
+// the expansion spec using the given mapping function to resolve the
+// values of variables.
+func Expand(input string, mapping func(string) string) string {
+	var buf bytes.Buffer
+	checkpoint := 0
+	for cursor := 0; cursor < len(input); cursor++ {
+		if input[cursor] == operator && cursor+1 < len(input) {
+			// Copy the portion of the input string since the last
+			// checkpoint into the buffer
+			buf.WriteString(input[checkpoint:cursor])
+
+			// Attempt to read the variable name as defined by the
+			// syntax from the input string
+			read, isVar, advance := tryReadVariableName(input[cursor+1:])
+
+			if isVar {
+				// We were able to read a variable name correctly;
+				// apply the mapping to the variable name and copy the
+				// bytes into the buffer
+				buf.WriteString(mapping(read))
+			} else {
+				// Not a variable name; copy the read bytes into the buffer
+				buf.WriteString(read)
+			}
+
+			// Advance the cursor in the input string to account for
+			// bytes consumed to read the variable name expression
+			cursor += advance
+
+			// Advance the checkpoint in the input string
+			checkpoint = cursor + 1
+		}
+	}
+
+	// Return the buffer and any remaining unwritten bytes in the
+	// input string.
+	return buf.String() + input[checkpoint:]
+}
+
+// tryReadVariableName attempts to read a variable name from the input
+// string and returns the content read from the input, whether that content
+// represents a variable name to perform mapping on, and the number of bytes
+// consumed in the input string.
+//
+// The input string is assumed not to contain the initial operator.
+func tryReadVariableName(input string) (string, bool, int) {
+	switch input[0] {
+	case operator:
+		// Escaped operator; return it.
+		return input[0:1], false, 1
+	case referenceOpener:
+		// Scan to expression closer
+		for i := 1; i < len(input); i++ {
+			if input[i] == referenceCloser {
+				return input[1:i], true, i + 1
+			}
+		}
+
+		// Incomplete reference; return it.
+		return string(operator) + string(referenceOpener), false, 1
+	default:
+		// Not the beginning of an expression, ie, an operator
+		// that doesn't begin an expression.  Return the operator
+		// and the first rune in the string.
+		return (string(operator) + string(input[0])), false, 1
+	}
+}

--- a/third_party/forked/golang/expansion/expand_test.go
+++ b/third_party/forked/golang/expansion/expand_test.go
@@ -1,0 +1,285 @@
+package expansion
+
+import (
+	"testing"
+
+	"github.com/cloudboss/easyto/pkg/initial/vmspec"
+)
+
+func TestMapReference(t *testing.T) {
+	envs := vmspec.NameValueSource{
+		{
+			Name:  "FOO",
+			Value: "bar",
+		},
+		{
+			Name:  "ZOO",
+			Value: "$(FOO)-1",
+		},
+		{
+			Name:  "BLU",
+			Value: "$(ZOO)-2",
+		},
+	}
+
+	declaredEnv := map[string]string{
+		"FOO": "bar",
+		"ZOO": "$(FOO)-1",
+		"BLU": "$(ZOO)-2",
+	}
+
+	serviceEnv := map[string]string{}
+
+	mapping := MappingFuncFor(declaredEnv, serviceEnv)
+
+	for _, env := range envs {
+		declaredEnv[env.Name] = Expand(env.Value, mapping)
+	}
+
+	expectedEnv := map[string]string{
+		"FOO": "bar",
+		"ZOO": "bar-1",
+		"BLU": "bar-1-2",
+	}
+
+	for k, v := range expectedEnv {
+		if e, a := v, declaredEnv[k]; e != a {
+			t.Errorf("Expected %v, got %v", e, a)
+		} else {
+			delete(declaredEnv, k)
+		}
+	}
+
+	if len(declaredEnv) != 0 {
+		t.Errorf("Unexpected keys in declared env: %v", declaredEnv)
+	}
+}
+
+func TestMapping(t *testing.T) {
+	context := map[string]string{
+		"VAR_A":     "A",
+		"VAR_B":     "B",
+		"VAR_C":     "C",
+		"VAR_REF":   "$(VAR_A)",
+		"VAR_EMPTY": "",
+	}
+	mapping := MappingFuncFor(context)
+
+	doExpansionTest(t, mapping)
+}
+
+func TestMappingDual(t *testing.T) {
+	context := map[string]string{
+		"VAR_A":     "A",
+		"VAR_EMPTY": "",
+	}
+	context2 := map[string]string{
+		"VAR_B":   "B",
+		"VAR_C":   "C",
+		"VAR_REF": "$(VAR_A)",
+	}
+	mapping := MappingFuncFor(context, context2)
+
+	doExpansionTest(t, mapping)
+}
+
+func doExpansionTest(t *testing.T, mapping func(string) string) {
+	cases := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "whole string",
+			input:    "$(VAR_A)",
+			expected: "A",
+		},
+		{
+			name:     "repeat",
+			input:    "$(VAR_A)-$(VAR_A)",
+			expected: "A-A",
+		},
+		{
+			name:     "beginning",
+			input:    "$(VAR_A)-1",
+			expected: "A-1",
+		},
+		{
+			name:     "middle",
+			input:    "___$(VAR_B)___",
+			expected: "___B___",
+		},
+		{
+			name:     "end",
+			input:    "___$(VAR_C)",
+			expected: "___C",
+		},
+		{
+			name:     "compound",
+			input:    "$(VAR_A)_$(VAR_B)_$(VAR_C)",
+			expected: "A_B_C",
+		},
+		{
+			name:     "escape & expand",
+			input:    "$$(VAR_B)_$(VAR_A)",
+			expected: "$(VAR_B)_A",
+		},
+		{
+			name:     "compound escape",
+			input:    "$$(VAR_A)_$$(VAR_B)",
+			expected: "$(VAR_A)_$(VAR_B)",
+		},
+		{
+			name:     "mixed in escapes",
+			input:    "f000-$$VAR_A",
+			expected: "f000-$VAR_A",
+		},
+		{
+			name:     "backslash escape ignored",
+			input:    "foo\\$(VAR_C)bar",
+			expected: "foo\\Cbar",
+		},
+		{
+			name:     "backslash escape ignored",
+			input:    "foo\\\\$(VAR_C)bar",
+			expected: "foo\\\\Cbar",
+		},
+		{
+			name:     "lots of backslashes",
+			input:    "foo\\\\\\\\$(VAR_A)bar",
+			expected: "foo\\\\\\\\Abar",
+		},
+		{
+			name:     "nested var references",
+			input:    "$(VAR_A$(VAR_B))",
+			expected: "$(VAR_A$(VAR_B))",
+		},
+		{
+			name:     "nested var references second type",
+			input:    "$(VAR_A$(VAR_B)",
+			expected: "$(VAR_A$(VAR_B)",
+		},
+		{
+			name:     "value is a reference",
+			input:    "$(VAR_REF)",
+			expected: "$(VAR_A)",
+		},
+		{
+			name:     "value is a reference x 2",
+			input:    "%%$(VAR_REF)--$(VAR_REF)%%",
+			expected: "%%$(VAR_A)--$(VAR_A)%%",
+		},
+		{
+			name:     "empty var",
+			input:    "foo$(VAR_EMPTY)bar",
+			expected: "foobar",
+		},
+		{
+			name:     "unterminated expression",
+			input:    "foo$(VAR_Awhoops!",
+			expected: "foo$(VAR_Awhoops!",
+		},
+		{
+			name:     "expression without operator",
+			input:    "f00__(VAR_A)__",
+			expected: "f00__(VAR_A)__",
+		},
+		{
+			name:     "shell special vars pass through",
+			input:    "$?_boo_$!",
+			expected: "$?_boo_$!",
+		},
+		{
+			name:     "bare operators are ignored",
+			input:    "$VAR_A",
+			expected: "$VAR_A",
+		},
+		{
+			name:     "undefined vars are passed through",
+			input:    "$(VAR_DNE)",
+			expected: "$(VAR_DNE)",
+		},
+		{
+			name:     "multiple (even) operators, var undefined",
+			input:    "$$$$$$(BIG_MONEY)",
+			expected: "$$$(BIG_MONEY)",
+		},
+		{
+			name:     "multiple (even) operators, var defined",
+			input:    "$$$$$$(VAR_A)",
+			expected: "$$$(VAR_A)",
+		},
+		{
+			name:     "multiple (odd) operators, var undefined",
+			input:    "$$$$$$$(GOOD_ODDS)",
+			expected: "$$$$(GOOD_ODDS)",
+		},
+		{
+			name:     "multiple (odd) operators, var defined",
+			input:    "$$$$$$$(VAR_A)",
+			expected: "$$$A",
+		},
+		{
+			name:     "missing open expression",
+			input:    "$VAR_A)",
+			expected: "$VAR_A)",
+		},
+		{
+			name:     "shell syntax ignored",
+			input:    "${VAR_A}",
+			expected: "${VAR_A}",
+		},
+		{
+			name:     "trailing incomplete expression not consumed",
+			input:    "$(VAR_B)_______$(A",
+			expected: "B_______$(A",
+		},
+		{
+			name:     "trailing incomplete expression, no content, is not consumed",
+			input:    "$(VAR_C)_______$(",
+			expected: "C_______$(",
+		},
+		{
+			name:     "operator at end of input string is preserved",
+			input:    "$(VAR_A)foobarzab$",
+			expected: "Afoobarzab$",
+		},
+		{
+			name:     "shell escaped incomplete expr",
+			input:    "foo-\\$(VAR_A",
+			expected: "foo-\\$(VAR_A",
+		},
+		{
+			name:     "lots of $( in middle",
+			input:    "--$($($($($--",
+			expected: "--$($($($($--",
+		},
+		{
+			name:     "lots of $( in beginning",
+			input:    "$($($($($--foo$(",
+			expected: "$($($($($--foo$(",
+		},
+		{
+			name:     "lots of $( at end",
+			input:    "foo0--$($($($(",
+			expected: "foo0--$($($($(",
+		},
+		{
+			name:     "escaped operators in variable names are not escaped",
+			input:    "$(foo$$var)",
+			expected: "$(foo$$var)",
+		},
+		{
+			name:     "newline not expanded",
+			input:    "\n",
+			expected: "\n",
+		},
+	}
+
+	for _, tc := range cases {
+		expanded := Expand(tc.input, mapping)
+		if e, a := tc.expected, expanded; e != a {
+			t.Errorf("%v: expected %q, got %q", tc.name, e, a)
+		}
+	}
+}


### PR DESCRIPTION
This enables variables of the form $(VAR) to be expanded in other environment variables and command arguments.

This includes the Kubernetes expansion package to expand the variables.