### PR TITLE
Set a default PATH if not defined

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,9 @@ The full specification is as follows:
 
 `env`: (Optional, type _list_ of [_name-value_](#name-value-object) objects, default `[]`) - The names and values of environment variables to be passed to `command`. Values can refer to variables defined in `env` and `env-from` (see [variable expansion](#variable-expansion)).
 
+> [!NOTE]
+> If the `PATH` environment variable is not set in the container image or user data, a default `PATH` of `/usr/local/bin:/usr/local/sbin:/usr/bin:/usr/sbin:/bin:/sbin` will be set on boot.
+
 `env-from`: (Optional, type _list_ of [_env-from_](#env-from-object) objects, default `[]`) - Environment variables to be passed to `command`, to be retrieved from the given sources.
 
 `init-scripts`: (Optional, type _list_ of _string_, default `[]`) - A list of scripts to run on boot. They must start with `#!` and have a valid interpreter available in the image. For lightweight images that have no shell in the container image they are derived from, `/.easyto/bin/busybox sh` can be used. The AMI will always have `/.easyto/bin/busybox` available as a source of utilities that can be used in the scripts. Init scripts run just before any services have started and `command` is executed.

--- a/pkg/initial/initial/initial.go
+++ b/pkg/initial/initial/initial.go
@@ -28,10 +28,9 @@ import (
 )
 
 const (
-	fileCACerts    = "amazon.pem"
-	fileMounts     = constants.DirProc + "/mounts"
-	execBits       = 0111
-	pathEnvDefault = "/usr/local/bin:/usr/local/sbin:/usr/bin:/usr/sbin:/bin:/sbin"
+	fileCACerts = "amazon.pem"
+	fileMounts  = constants.DirProc + "/mounts"
+	execBits    = 0111
 )
 
 type link struct {
@@ -288,10 +287,7 @@ func fullCommand(spec *vmspec.VMSpec, env vmspec.NameValueSource) ([]string, err
 		exe = []string{"/bin/sh"}
 	}
 
-	pathEnv := pathEnvDefault
-	if pathVMSpec, i := spec.Env.Find("PATH"); i >= 0 {
-		pathEnv = pathVMSpec
-	}
+	pathEnv, _ := spec.Env.Find("PATH")
 
 	if !strings.HasPrefix(exe[0], constants.DirRoot) {
 		executablePath, err := findExecutableInPath(exe[0], pathEnv)

--- a/pkg/initial/vmspec/vmspec.go
+++ b/pkg/initial/vmspec/vmspec.go
@@ -10,6 +10,10 @@ import (
 	"dario.cat/mergo"
 )
 
+const (
+	pathEnvDefault = "/usr/local/bin:/usr/local/sbin:/usr/bin:/usr/sbin:/bin:/sbin"
+)
+
 var DefaultServices = []string{"chrony", "ssh"}
 
 type VMSpec struct {
@@ -43,6 +47,11 @@ func (v *VMSpec) Merge(other *VMSpec) error {
 }
 
 func (v *VMSpec) SetDefaults() {
+	_, i := v.Env.Find("PATH")
+	if i < 0 {
+		pathEnv := NameValue{Name: "PATH", Value: pathEnvDefault}
+		v.Env = append(v.Env, pathEnv)
+	}
 	if v.Security.RunAsGroupID == nil {
 		v.Security.RunAsGroupID = p(0)
 	}

--- a/pkg/initial/vmspec/vmspec_test.go
+++ b/pkg/initial/vmspec/vmspec_test.go
@@ -18,6 +18,12 @@ func Test_VMSpec_Merge(t *testing.T) {
 			orig:        &VMSpec{},
 			other:       &VMSpec{},
 			expected: &VMSpec{
+				Env: NameValueSource{
+					{
+						Name:  "PATH",
+						Value: pathEnvDefault,
+					},
+				},
 				Security: SecurityContext{
 					RunAsGroupID: p(0),
 					RunAsUserID:  p(0),
@@ -33,6 +39,12 @@ func Test_VMSpec_Merge(t *testing.T) {
 			},
 			expected: &VMSpec{
 				Debug: true,
+				Env: NameValueSource{
+					{
+						Name:  "PATH",
+						Value: pathEnvDefault,
+					},
+				},
 				Security: SecurityContext{
 					RunAsGroupID: p(0),
 					RunAsUserID:  p(0),
@@ -47,6 +59,12 @@ func Test_VMSpec_Merge(t *testing.T) {
 			},
 			expected: &VMSpec{
 				ReplaceInit: true,
+				Env: NameValueSource{
+					{
+						Name:  "PATH",
+						Value: pathEnvDefault,
+					},
+				},
 				Security: SecurityContext{
 					RunAsGroupID: p(0),
 					RunAsUserID:  p(0),
@@ -66,6 +84,12 @@ func Test_VMSpec_Merge(t *testing.T) {
 			expected: &VMSpec{
 				Args:    []string{"xyz"},
 				Command: []string{"/usr/bin/abc"},
+				Env: NameValueSource{
+					{
+						Name:  "PATH",
+						Value: pathEnvDefault,
+					},
+				},
 				Security: SecurityContext{
 					RunAsGroupID: p(0),
 					RunAsUserID:  p(0),
@@ -84,6 +108,12 @@ func Test_VMSpec_Merge(t *testing.T) {
 			expected: &VMSpec{
 				Args:    nil,
 				Command: []string{"/usr/bin/abc"},
+				Env: NameValueSource{
+					{
+						Name:  "PATH",
+						Value: pathEnvDefault,
+					},
+				},
 				Security: SecurityContext{
 					RunAsGroupID: p(0),
 					RunAsUserID:  p(0),
@@ -107,6 +137,12 @@ func Test_VMSpec_Merge(t *testing.T) {
 				},
 			},
 			expected: &VMSpec{
+				Env: NameValueSource{
+					{
+						Name:  "PATH",
+						Value: pathEnvDefault,
+					},
+				},
 				Security: SecurityContext{
 					ReadonlyRootFS: true,
 					RunAsGroupID:   p(1234),
@@ -133,6 +169,12 @@ func Test_VMSpec_Merge(t *testing.T) {
 				},
 			},
 			expected: &VMSpec{
+				Env: NameValueSource{
+					{
+						Name:  "PATH",
+						Value: pathEnvDefault,
+					},
+				},
 				Security: SecurityContext{
 					ReadonlyRootFS: true,
 					RunAsGroupID:   p(0),
@@ -151,6 +193,12 @@ func Test_VMSpec_Merge(t *testing.T) {
 			},
 			expected: &VMSpec{
 				DisableServices: []string{"ssh"},
+				Env: NameValueSource{
+					{
+						Name:  "PATH",
+						Value: pathEnvDefault,
+					},
+				},
 				Security: SecurityContext{
 					RunAsGroupID: p(0),
 					RunAsUserID:  p(0),
@@ -186,6 +234,12 @@ func Test_VMSpec_Merge(t *testing.T) {
 				},
 			},
 			expected: &VMSpec{
+				Env: NameValueSource{
+					{
+						Name:  "PATH",
+						Value: pathEnvDefault,
+					},
+				},
 				Volumes: Volumes{
 					{
 						SSM: &SSMVolumeSource{
@@ -222,6 +276,12 @@ func Test_VMSpec_Merge(t *testing.T) {
 			},
 			other: &VMSpec{},
 			expected: &VMSpec{
+				Env: NameValueSource{
+					{
+						Name:  "PATH",
+						Value: pathEnvDefault,
+					},
+				},
 				Volumes: Volumes{
 					{
 						SSM: &SSMVolumeSource{
@@ -260,6 +320,12 @@ func Test_VMSpec_Merge(t *testing.T) {
 			},
 			other: &VMSpec{},
 			expected: &VMSpec{
+				Env: NameValueSource{
+					{
+						Name:  "PATH",
+						Value: pathEnvDefault,
+					},
+				},
 				Volumes: Volumes{
 					{
 						SSM: &SSMVolumeSource{
@@ -286,7 +352,12 @@ func Test_VMSpec_Merge(t *testing.T) {
 				Env: NameValueSource{},
 			},
 			expected: &VMSpec{
-				Env: NameValueSource{},
+				Env: NameValueSource{
+					{
+						Name:  "PATH",
+						Value: pathEnvDefault,
+					},
+				},
 				Security: SecurityContext{
 					RunAsGroupID: p(0),
 					RunAsUserID:  p(0),
@@ -317,6 +388,10 @@ func Test_VMSpec_Merge(t *testing.T) {
 						Name:  "abc",
 						Value: "yxz",
 					},
+					{
+						Name:  "PATH",
+						Value: pathEnvDefault,
+					},
 				},
 				Security: SecurityContext{
 					RunAsGroupID: p(0),
@@ -343,6 +418,36 @@ func Test_VMSpec_Merge(t *testing.T) {
 						Name:  "abc",
 						Value: "xyz",
 					},
+					{
+						Name:  "PATH",
+						Value: pathEnvDefault,
+					},
+				},
+				Security: SecurityContext{
+					RunAsGroupID: p(0),
+					RunAsUserID:  p(0),
+				},
+			},
+		},
+		{
+			description: "NameValue PATH exists so not merged",
+			orig: &VMSpec{
+				Env: NameValueSource{
+					{
+						Name:  "PATH",
+						Value: "/bin:/usr/bin",
+					},
+				},
+			},
+			other: &VMSpec{
+				Env: NameValueSource{},
+			},
+			expected: &VMSpec{
+				Env: NameValueSource{
+					{
+						Name:  "PATH",
+						Value: "/bin:/usr/bin",
+					},
 				},
 				Security: SecurityContext{
 					RunAsGroupID: p(0),
@@ -368,6 +473,10 @@ func Test_VMSpec_Merge(t *testing.T) {
 					{
 						Name:  "abc",
 						Value: "xyz",
+					},
+					{
+						Name:  "PATH",
+						Value: pathEnvDefault,
 					},
 				},
 				Security: SecurityContext{
@@ -415,6 +524,10 @@ func Test_VMSpec_Merge(t *testing.T) {
 					{
 						Name:  "bar",
 						Value: "foo",
+					},
+					{
+						Name:  "PATH",
+						Value: pathEnvDefault,
 					},
 				},
 				Security: SecurityContext{
@@ -491,6 +604,10 @@ func Test_VMSpec_Merge(t *testing.T) {
 					{
 						Name:  "xyz",
 						Value: "123",
+					},
+					{
+						Name:  "PATH",
+						Value: pathEnvDefault,
 					},
 				},
 				Security: SecurityContext{


### PR DESCRIPTION
If the container image or user data do not set a `PATH` environment variable, then set a default value for it on boot.