### PR TITLE
Add copy-builder subcommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,16 @@ To create an AMI, run the `ami` subcommand. For example, to create an AMI called
 easyto ami -a postgres-16.2-bullseye -c postgres:16.2-bullseye -s subnet-e358acdfe25b8fb3b --services=chrony,ssh
 ```
 
+### Fast vs slow mode
+
+The `ami` subcommand runs in one of *fast* or *slow* build modes.
+
+In fast mode, the build instance is created from an AMI that has easyto preinstalled. This is the default when the builder AMI matching your easyto version is available in your region. The AMI with the name `ghcr.io-cloudboss-easyto-builder-<version>` is searched for in your own account and in the official easyto account, where `<version>` is the same as the output of running `easyto version`.
+
+In slow mode, the build uses a Debian base AMI and copies easyto to the instance during the build process. This is slower but works without needing the builder AMI to be available. Slow mode is used automatically as a fallback when the fast mode AMI is not found.
+
+You can also specify a custom builder image with `--builder-image`, with `--builder-image-mode` to specify fast mode if easyto is preinstalled on it. When easyto is preinstalled, it must be the full bundle including assets directory, and the `easyto` executable or a link to it must be on the `PATH`.
+
 ### Command line options
 
 The `ami` subcommand takes the following options:
@@ -49,6 +59,12 @@ The `ami` subcommand takes the following options:
 `--login-shell`: (Optional, default `/.easyto/bin/sh`) - Shell to use for the login user if ssh service is enabled.
 
 `--login-user`: (Optional, default `cloudboss`) - Login user to create in the AMI if ssh service is enabled.
+
+`--builder-image`: (Optional) - AMI name pattern or ID for the builder image. If not specified, uses the easyto builder AMI matching the current version, falling back to Debian if not found.
+
+`--builder-image-login-user`: (Optional, default `cloudboss`) - SSH login user for the builder image when using `--builder-image`.
+
+`--builder-image-mode`: (Optional, default `slow`) - Build mode to use with `--builder-image` and has no effect if it is not defined. Must be one of `fast` or `slow`.
 
 `--asset-directory` or `-A`: (Optional) - Path to a directory containing asset files. Normally not needed unless changing the layout of directories contained in the release.
 

--- a/cmd/easyto/tree/copy_builder.go
+++ b/cmd/easyto/tree/copy_builder.go
@@ -1,0 +1,72 @@
+package tree
+
+import (
+	"context"
+	"os"
+
+	"github.com/cloudboss/easyto/pkg/constants"
+	"github.com/cloudboss/easyto/pkg/copybuilder"
+	"github.com/spf13/cobra"
+)
+
+var (
+	copyBuilderCfg = &copyBuilderConfig{}
+	CopyBuilderCmd = &cobra.Command{
+		Use:   "copy-builder",
+		Short: "Copy the official easyto builder AMI to your account/region",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cmd.SilenceUsage = true
+
+			ctx := context.Background()
+
+			cfg := copybuilder.Config{
+				SourceRegion: copyBuilderCfg.sourceRegion,
+				DestRegion:   copyBuilderCfg.destRegion,
+				Version:      copyBuilderCfg.version,
+				Name:         copyBuilderCfg.name,
+				CopyTags:     copyBuilderCfg.copyTags,
+				Wait:         copyBuilderCfg.wait,
+				Output:       os.Stdout,
+			}
+
+			result, err := copybuilder.Copy(ctx, cfg)
+			if err != nil {
+				return err
+			}
+
+			cmd.Printf("Copied %s (%s) to %s (%s)\n",
+				result.SourceName, result.SourceAMI,
+				result.DestName, result.DestAMI)
+			return nil
+		},
+	}
+)
+
+type copyBuilderConfig struct {
+	sourceRegion string
+	destRegion   string
+	version      string
+	name         string
+	copyTags     bool
+	wait         bool
+}
+
+func init() {
+	CopyBuilderCmd.Flags().StringVar(&copyBuilderCfg.sourceRegion, "source-region", "us-east-1",
+		"AWS region where the official builder AMI is located.")
+
+	CopyBuilderCmd.Flags().StringVar(&copyBuilderCfg.destRegion, "dest-region", "",
+		"AWS region to copy the AMI to. Defaults to your configured AWS region.")
+
+	CopyBuilderCmd.Flags().StringVar(&copyBuilderCfg.version, "version", constants.ETVersion,
+		"Version of the builder AMI to copy.")
+
+	CopyBuilderCmd.Flags().StringVar(&copyBuilderCfg.name, "name", "",
+		"Name for the copied AMI. Defaults to the source AMI name.")
+
+	CopyBuilderCmd.Flags().BoolVar(&copyBuilderCfg.copyTags, "copy-tags", true,
+		"Copy tags from the source AMI.")
+
+	CopyBuilderCmd.Flags().BoolVar(&copyBuilderCfg.wait, "wait", true,
+		"Wait for the AMI copy to complete.")
+}

--- a/cmd/easyto/tree/root.go
+++ b/cmd/easyto/tree/root.go
@@ -13,5 +13,6 @@ var (
 
 func init() {
 	RootCmd.AddCommand(AMICmd)
+	RootCmd.AddCommand(CopyBuilderCmd)
 	RootCmd.AddCommand(VersionCmd)
 }

--- a/pkg/copybuilder/copybuilder.go
+++ b/pkg/copybuilder/copybuilder.go
@@ -1,0 +1,174 @@
+package copybuilder
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	"github.com/cloudboss/easyto/pkg/constants"
+)
+
+var (
+	ErrNotFound = errors.New("builder AMI not found")
+)
+
+type DescribeImagesAPI interface {
+	DescribeImages(
+		ctx context.Context,
+		params *ec2.DescribeImagesInput,
+		optFns ...func(*ec2.Options),
+	) (*ec2.DescribeImagesOutput, error)
+}
+
+type CopyImageAPI interface {
+	CopyImage(
+		ctx context.Context,
+		params *ec2.CopyImageInput,
+		optFns ...func(*ec2.Options),
+	) (*ec2.CopyImageOutput, error)
+}
+
+type ImageWaiter interface {
+	Wait(
+		ctx context.Context,
+		params *ec2.DescribeImagesInput,
+		maxWaitDur time.Duration,
+		optFns ...func(*ec2.ImageAvailableWaiterOptions),
+	) error
+}
+
+type Config struct {
+	SourceRegion string
+	DestRegion   string
+	Version      string
+	Name         string
+	CopyTags     bool
+	Wait         bool
+	Output       io.Writer
+}
+
+type Result struct {
+	SourceAMI  string
+	SourceName string
+	DestAMI    string
+	DestName   string
+}
+
+func Copy(ctx context.Context, cfg Config) (*Result, error) {
+	sourceCfg, err := config.LoadDefaultConfig(ctx, config.WithRegion(cfg.SourceRegion))
+	if err != nil {
+		return nil, fmt.Errorf("failed to load AWS config for source region: %w", err)
+	}
+	sourceClient := ec2.NewFromConfig(sourceCfg)
+
+	destRegion := cfg.DestRegion
+	if destRegion == "" {
+		destCfg, err := config.LoadDefaultConfig(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("failed to load default AWS config: %w", err)
+		}
+		destRegion = destCfg.Region
+	}
+
+	destCfg, err := config.LoadDefaultConfig(ctx, config.WithRegion(destRegion))
+	if err != nil {
+		return nil, fmt.Errorf("failed to load AWS config for dest region: %w", err)
+	}
+	destClient := ec2.NewFromConfig(destCfg)
+
+	var waiter ImageWaiter
+	if cfg.Wait {
+		waiter = ec2.NewImageAvailableWaiter(destClient)
+	}
+
+	return CopyWithClients(ctx, cfg, sourceClient, destClient, waiter)
+}
+
+func CopyWithClients(
+	ctx context.Context,
+	cfg Config,
+	sourceClient DescribeImagesAPI,
+	destClient CopyImageAPI,
+	waiter ImageWaiter,
+) (*Result, error) {
+	amiName := constants.AMIPatternCloudboss + cfg.Version
+	log(cfg.Output, "Looking for AMI %s in %s...\n", amiName, cfg.SourceRegion)
+
+	sourceAMI, err := findAMI(ctx, sourceClient, amiName)
+	if err != nil {
+		return nil, err
+	}
+	log(cfg.Output, "Found source AMI %s\n", *sourceAMI.ImageId)
+
+	destName := cfg.Name
+	if destName == "" {
+		destName = *sourceAMI.Name
+	}
+
+	log(cfg.Output, "Copying AMI to %s as %s...\n", cfg.DestRegion, destName)
+
+	copyOutput, err := destClient.CopyImage(ctx, &ec2.CopyImageInput{
+		Name:          aws.String(destName),
+		SourceImageId: sourceAMI.ImageId,
+		SourceRegion:  aws.String(cfg.SourceRegion),
+		CopyImageTags: aws.Bool(cfg.CopyTags),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to copy AMI: %w", err)
+	}
+
+	log(cfg.Output, "Created AMI %s\n", *copyOutput.ImageId)
+
+	result := &Result{
+		SourceAMI:  *sourceAMI.ImageId,
+		SourceName: *sourceAMI.Name,
+		DestAMI:    *copyOutput.ImageId,
+		DestName:   destName,
+	}
+
+	if waiter != nil {
+		log(cfg.Output, "Waiting for AMI to become available...\n")
+		err = waiter.Wait(ctx, &ec2.DescribeImagesInput{
+			ImageIds: []string{*copyOutput.ImageId},
+		}, 30*time.Minute)
+		if err != nil {
+			return result, fmt.Errorf("AMI copy initiated but wait failed: %w", err)
+		}
+		log(cfg.Output, "AMI is now available\n")
+	}
+
+	return result, nil
+}
+
+func log(w io.Writer, format string, args ...any) {
+	if w != nil {
+		fmt.Fprintf(w, format, args...)
+	}
+}
+
+func findAMI(ctx context.Context, client DescribeImagesAPI, name string) (*ec2types.Image, error) {
+	output, err := client.DescribeImages(ctx, &ec2.DescribeImagesInput{
+		Filters: []ec2types.Filter{
+			{
+				Name:   aws.String("name"),
+				Values: []string{name},
+			},
+		},
+		Owners: []string{constants.AWSAccountCloudboss},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to describe images: %w", err)
+	}
+
+	if len(output.Images) == 0 {
+		return nil, fmt.Errorf("%w: %s", ErrNotFound, name)
+	}
+
+	return &output.Images[0], nil
+}

--- a/pkg/copybuilder/copybuilder_test.go
+++ b/pkg/copybuilder/copybuilder_test.go
@@ -1,0 +1,272 @@
+package copybuilder
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type mockDescribeImagesClient struct {
+	images []ec2types.Image
+	err    error
+}
+
+func (m *mockDescribeImagesClient) DescribeImages(
+	ctx context.Context,
+	input *ec2.DescribeImagesInput,
+	opts ...func(*ec2.Options),
+) (*ec2.DescribeImagesOutput, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
+	return &ec2.DescribeImagesOutput{Images: m.images}, nil
+}
+
+type mockCopyImageClient struct {
+	imageID string
+	err     error
+}
+
+func (m *mockCopyImageClient) CopyImage(
+	ctx context.Context,
+	input *ec2.CopyImageInput,
+	opts ...func(*ec2.Options),
+) (*ec2.CopyImageOutput, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
+	return &ec2.CopyImageOutput{ImageId: aws.String(m.imageID)}, nil
+}
+
+type mockWaiter struct {
+	err error
+}
+
+func (m *mockWaiter) Wait(
+	ctx context.Context,
+	params *ec2.DescribeImagesInput,
+	maxWaitDur time.Duration,
+	optFns ...func(*ec2.ImageAvailableWaiterOptions),
+) error {
+	return m.err
+}
+
+func TestFindAMI(t *testing.T) {
+	ctx := context.Background()
+
+	testCases := []struct {
+		name        string
+		client      *mockDescribeImagesClient
+		amiName     string
+		expectedID  string
+		expectedErr error
+	}{
+		{
+			name: "Found image",
+			client: &mockDescribeImagesClient{
+				images: []ec2types.Image{
+					{
+						ImageId: aws.String("ami-123"),
+						Name:    aws.String("test-ami"),
+					},
+				},
+			},
+			amiName:    "test-ami",
+			expectedID: "ami-123",
+		},
+		{
+			name:        "No images found",
+			client:      &mockDescribeImagesClient{images: []ec2types.Image{}},
+			amiName:     "nonexistent",
+			expectedErr: ErrNotFound,
+		},
+		{
+			name:        "API error",
+			client:      &mockDescribeImagesClient{err: errors.New("API error")},
+			amiName:     "test-ami",
+			expectedErr: errors.New("failed to describe images"),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result, err := findAMI(ctx, tc.client, tc.amiName)
+			if tc.expectedErr != nil {
+				require.Error(t, err)
+				if errors.Is(tc.expectedErr, ErrNotFound) {
+					assert.ErrorIs(t, err, ErrNotFound)
+				}
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tc.expectedID, *result.ImageId)
+		})
+	}
+}
+
+func TestCopyWithClients(t *testing.T) {
+	ctx := context.Background()
+
+	testCases := []struct {
+		name           string
+		cfg            Config
+		sourceClient   *mockDescribeImagesClient
+		destClient     *mockCopyImageClient
+		waiter         *mockWaiter
+		expectedResult *Result
+		expectedErr    string
+	}{
+		{
+			name: "Successful copy without wait",
+			cfg: Config{
+				SourceRegion: "us-east-1",
+				Version:      "v1.0.0",
+			},
+			sourceClient: &mockDescribeImagesClient{
+				images: []ec2types.Image{
+					{
+						ImageId: aws.String("ami-source"),
+						Name:    aws.String("ghcr.io-cloudboss-easyto-builder-v1.0.0"),
+					},
+				},
+			},
+			destClient: &mockCopyImageClient{imageID: "ami-dest"},
+			waiter:     nil,
+			expectedResult: &Result{
+				SourceAMI:  "ami-source",
+				SourceName: "ghcr.io-cloudboss-easyto-builder-v1.0.0",
+				DestAMI:    "ami-dest",
+				DestName:   "ghcr.io-cloudboss-easyto-builder-v1.0.0",
+			},
+		},
+		{
+			name: "Successful copy with custom name",
+			cfg: Config{
+				SourceRegion: "us-east-1",
+				Version:      "v1.0.0",
+				Name:         "my-custom-name",
+			},
+			sourceClient: &mockDescribeImagesClient{
+				images: []ec2types.Image{
+					{
+						ImageId: aws.String("ami-source"),
+						Name:    aws.String("ghcr.io-cloudboss-easyto-builder-v1.0.0"),
+					},
+				},
+			},
+			destClient: &mockCopyImageClient{imageID: "ami-dest"},
+			waiter:     nil,
+			expectedResult: &Result{
+				SourceAMI:  "ami-source",
+				SourceName: "ghcr.io-cloudboss-easyto-builder-v1.0.0",
+				DestAMI:    "ami-dest",
+				DestName:   "my-custom-name",
+			},
+		},
+		{
+			name: "Successful copy with wait",
+			cfg: Config{
+				SourceRegion: "us-east-1",
+				Version:      "v1.0.0",
+				Wait:         true,
+			},
+			sourceClient: &mockDescribeImagesClient{
+				images: []ec2types.Image{
+					{
+						ImageId: aws.String("ami-source"),
+						Name:    aws.String("ghcr.io-cloudboss-easyto-builder-v1.0.0"),
+					},
+				},
+			},
+			destClient: &mockCopyImageClient{imageID: "ami-dest"},
+			waiter:     &mockWaiter{},
+			expectedResult: &Result{
+				SourceAMI:  "ami-source",
+				SourceName: "ghcr.io-cloudboss-easyto-builder-v1.0.0",
+				DestAMI:    "ami-dest",
+				DestName:   "ghcr.io-cloudboss-easyto-builder-v1.0.0",
+			},
+		},
+		{
+			name: "Source AMI not found",
+			cfg: Config{
+				SourceRegion: "us-east-1",
+				Version:      "v1.0.0",
+			},
+			sourceClient: &mockDescribeImagesClient{images: []ec2types.Image{}},
+			destClient:   &mockCopyImageClient{imageID: "ami-dest"},
+			expectedErr:  "builder AMI not found",
+		},
+		{
+			name: "Copy fails",
+			cfg: Config{
+				SourceRegion: "us-east-1",
+				Version:      "v1.0.0",
+			},
+			sourceClient: &mockDescribeImagesClient{
+				images: []ec2types.Image{
+					{
+						ImageId: aws.String("ami-source"),
+						Name:    aws.String("ghcr.io-cloudboss-easyto-builder-v1.0.0"),
+					},
+				},
+			},
+			destClient:  &mockCopyImageClient{err: errors.New("copy failed")},
+			expectedErr: "failed to copy AMI",
+		},
+		{
+			name: "Wait fails",
+			cfg: Config{
+				SourceRegion: "us-east-1",
+				Version:      "v1.0.0",
+				Wait:         true,
+			},
+			sourceClient: &mockDescribeImagesClient{
+				images: []ec2types.Image{
+					{
+						ImageId: aws.String("ami-source"),
+						Name:    aws.String("ghcr.io-cloudboss-easyto-builder-v1.0.0"),
+					},
+				},
+			},
+			destClient: &mockCopyImageClient{imageID: "ami-dest"},
+			waiter:     &mockWaiter{err: errors.New("timeout")},
+			expectedResult: &Result{
+				SourceAMI:  "ami-source",
+				SourceName: "ghcr.io-cloudboss-easyto-builder-v1.0.0",
+				DestAMI:    "ami-dest",
+				DestName:   "ghcr.io-cloudboss-easyto-builder-v1.0.0",
+			},
+			expectedErr: "AMI copy initiated but wait failed",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			var waiter ImageWaiter
+			if tc.waiter != nil {
+				waiter = tc.waiter
+			}
+
+			result, err := CopyWithClients(ctx, tc.cfg, tc.sourceClient, tc.destClient, waiter)
+
+			if tc.expectedErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tc.expectedErr)
+				if tc.expectedResult != nil {
+					assert.Equal(t, tc.expectedResult, result)
+				}
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tc.expectedResult, result)
+		})
+	}
+}


### PR DESCRIPTION
Allows users to copy the official easyto builder AMI from one region to another, enabling fast mode builds in regions where the builder AMI is not yet available.

Also documents fast vs slow build modes in the README.