### PR TITLE
Add --public flag to ami and copy-builder subcommands

### DIFF
--- a/cmd/easyto/tree/ami.go
+++ b/cmd/easyto/tree/ami.go
@@ -102,6 +102,7 @@ var (
 				"-var", fmt.Sprintf("ami_name=%s", amiCfg.amiName),
 				"-var", fmt.Sprintf("container_image=%s", amiCfg.containerImage),
 				"-var", fmt.Sprintf("debug=%t", amiCfg.debug),
+				"-var", fmt.Sprintf("is_public=%t", amiCfg.public),
 				"-var", fmt.Sprintf("login_user=%s", amiCfg.loginUser),
 				"-var", fmt.Sprintf("login_shell=%s", amiCfg.loginShell),
 				"-var", fmt.Sprintf("root_device_name=%s", amiCfg.rootDeviceName),
@@ -155,6 +156,7 @@ type amiConfig struct {
 	loginUser             string
 	loginShell            string
 	packerDir             string
+	public                bool
 	rootDeviceName        string
 	services              []string
 	size                  int
@@ -231,6 +233,8 @@ func init() {
 	AMICmd.MarkFlagRequired("subnet-id")
 
 	AMICmd.Flags().BoolVar(&amiCfg.debug, "debug", false, "Enable debug output.")
+
+	AMICmd.Flags().BoolVar(&amiCfg.public, "public", false, "Make the AMI and its snapshots public.")
 }
 
 func expandPath(pth string) (string, error) {

--- a/cmd/easyto/tree/copy_builder.go
+++ b/cmd/easyto/tree/copy_builder.go
@@ -26,6 +26,7 @@ var (
 				Name:         copyBuilderCfg.name,
 				CopyTags:     copyBuilderCfg.copyTags,
 				Wait:         copyBuilderCfg.wait,
+				Public:       copyBuilderCfg.public,
 				Output:       os.Stdout,
 			}
 
@@ -49,6 +50,7 @@ type copyBuilderConfig struct {
 	name         string
 	copyTags     bool
 	wait         bool
+	public       bool
 }
 
 func init() {
@@ -69,4 +71,7 @@ func init() {
 
 	CopyBuilderCmd.Flags().BoolVar(&copyBuilderCfg.wait, "wait", true,
 		"Wait for the AMI copy to complete.")
+
+	CopyBuilderCmd.Flags().BoolVar(&copyBuilderCfg.public, "public", false,
+		"Make the copied AMI and its snapshots public.")
 }

--- a/pkg/copybuilder/copybuilder.go
+++ b/pkg/copybuilder/copybuilder.go
@@ -43,6 +43,29 @@ type ImageWaiter interface {
 	) error
 }
 
+type ModifyImageAttributeAPI interface {
+	ModifyImageAttribute(
+		ctx context.Context,
+		params *ec2.ModifyImageAttributeInput,
+		optFns ...func(*ec2.Options),
+	) (*ec2.ModifyImageAttributeOutput, error)
+}
+
+type ModifySnapshotAttributeAPI interface {
+	ModifySnapshotAttribute(
+		ctx context.Context,
+		params *ec2.ModifySnapshotAttributeInput,
+		optFns ...func(*ec2.Options),
+	) (*ec2.ModifySnapshotAttributeOutput, error)
+}
+
+type EC2Client interface {
+	DescribeImagesAPI
+	CopyImageAPI
+	ModifyImageAttributeAPI
+	ModifySnapshotAttributeAPI
+}
+
 type Config struct {
 	SourceRegion string
 	DestRegion   string
@@ -50,6 +73,7 @@ type Config struct {
 	Name         string
 	CopyTags     bool
 	Wait         bool
+	Public       bool
 	Output       io.Writer
 }
 
@@ -83,11 +107,11 @@ func Copy(ctx context.Context, cfg Config) (*Result, error) {
 	destClient := ec2.NewFromConfig(destCfg)
 
 	var waiter ImageWaiter
-	if cfg.Wait {
+	if cfg.Wait || cfg.Public {
 		waiter = ec2.NewImageAvailableWaiter(destClient)
 	}
 
-	return CopyWithClients(ctx, cfg, sourceClient, destClient, waiter)
+	return CopyWithClients(ctx, cfg, sourceClient, destClient, destClient, waiter)
 }
 
 func CopyWithClients(
@@ -95,6 +119,7 @@ func CopyWithClients(
 	cfg Config,
 	sourceClient DescribeImagesAPI,
 	destClient CopyImageAPI,
+	destEC2Client EC2Client,
 	waiter ImageWaiter,
 ) (*Result, error) {
 	amiName := constants.AMIPatternCloudboss + cfg.Version
@@ -143,7 +168,59 @@ func CopyWithClients(
 		log(cfg.Output, "AMI is now available\n")
 	}
 
+	if cfg.Public {
+		err = makePublic(ctx, cfg, destEC2Client, *copyOutput.ImageId)
+		if err != nil {
+			return result, err
+		}
+	}
+
 	return result, nil
+}
+
+func makePublic(ctx context.Context, cfg Config, client EC2Client, amiID string) error {
+	log(cfg.Output, "Making AMI %s public...\n", amiID)
+
+	_, err := client.ModifyImageAttribute(ctx, &ec2.ModifyImageAttributeInput{
+		ImageId: aws.String(amiID),
+		LaunchPermission: &ec2types.LaunchPermissionModifications{
+			Add: []ec2types.LaunchPermission{
+				{Group: ec2types.PermissionGroupAll},
+			},
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("failed to make AMI public: %w", err)
+	}
+
+	describeOutput, err := client.DescribeImages(ctx, &ec2.DescribeImagesInput{
+		ImageIds: []string{amiID},
+	})
+	if err != nil {
+		return fmt.Errorf("failed to describe AMI for snapshots: %w", err)
+	}
+
+	if len(describeOutput.Images) == 0 {
+		return fmt.Errorf("AMI %s not found after copy", amiID)
+	}
+
+	for _, bdm := range describeOutput.Images[0].BlockDeviceMappings {
+		if bdm.Ebs != nil && bdm.Ebs.SnapshotId != nil {
+			log(cfg.Output, "Making snapshot %s public...\n", *bdm.Ebs.SnapshotId)
+			_, err := client.ModifySnapshotAttribute(ctx, &ec2.ModifySnapshotAttributeInput{
+				SnapshotId:    bdm.Ebs.SnapshotId,
+				Attribute:     ec2types.SnapshotAttributeNameCreateVolumePermission,
+				OperationType: ec2types.OperationTypeAdd,
+				GroupNames:    []string{"all"},
+			})
+			if err != nil {
+				return fmt.Errorf("failed to make snapshot %s public: %w", *bdm.Ebs.SnapshotId, err)
+			}
+		}
+	}
+
+	log(cfg.Output, "AMI and snapshots are now public\n")
+	return nil
 }
 
 func log(w io.Writer, format string, args ...any) {


### PR DESCRIPTION
Add the ability to make AMIs and their snapshots public:

- ami --public: Passes is_public=true to packer, which sets ami_groups and snapshot_groups to ["all"]

- copy-builder --public: After copying the AMI and waiting for it to become available, modifies the image and snapshot attributes to make them publicly accessible