### PR TITLE
Add builder image publishing to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,15 @@ on:
     tags:
       - "v[0-9]+.[0-9]+.[0-9]+*"
 
+permissions:
+  contents: write
+  packages: write
+  id-token: write
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: cloudboss/easyto-builder
+
 jobs:
   test-build:
     uses: ./.github/workflows/common.yml
@@ -27,3 +36,119 @@ jobs:
           PRE_RELEASE: "${{ contains(github.ref_name, '-pre.') }}"
         with:
           args: artifacts/*.tar.gz
+
+  build-push-image:
+    runs-on: ubuntu-24.04
+    needs:
+      - test-build
+    outputs:
+      image-tag: ${{ steps.meta.outputs.tags }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: release-linux-amd64
+          path: _output/release
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: Dockerfile.buildimage
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            VERSION=${{ github.ref_name }}
+
+  build-ami:
+    runs-on: ubuntu-24.04
+    needs:
+      - build-push-image
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: release-linux-amd64
+          path: _output/release
+
+      - name: Extract easyto
+        run: |
+          tar -xzf _output/release/easyto-${{ github.ref_name }}-linux-amd64.tar.gz
+          echo "${PWD}/easyto-${{ github.ref_name }}/bin" >> "${GITHUB_PATH}"
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          aws-region: us-east-1
+
+      - name: Build AMI
+        run: |
+          easyto ami \
+            --ami-name "ghcr.io--cloudboss--easyto-builder--${{ github.ref_name }}" \
+            --container-image "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.ref_name }}" \
+            --subnet-id "${{ secrets.AWS_SUBNET_ID }}" \
+            --services chrony,ssh \
+            --size 8 \
+            --public \
+            --debug
+
+  copy-ami:
+    runs-on: ubuntu-24.04
+    needs:
+      - build-ami
+    strategy:
+      matrix:
+        region:
+          - us-west-2
+          - eu-west-1
+          - eu-central-1
+          - ap-northeast-1
+          - ap-southeast-1
+          - sa-east-1
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: release-linux-amd64
+          path: _output/release
+
+      - name: Extract easyto
+        run: |
+          tar -xzf _output/release/easyto-${{ github.ref_name }}-linux-amd64.tar.gz
+          echo "${PWD}/easyto-${{ github.ref_name }}/bin" >> "${GITHUB_PATH}"
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          aws-region: ${{ matrix.region }}
+
+      - name: Copy AMI to ${{ matrix.region }}
+        run: |
+          easyto copy-builder \
+            --source-region us-east-1 \
+            --dest-region "${{ matrix.region }}" \
+            --version "${{ github.ref_name }}" \
+            --public \
+            --wait


### PR DESCRIPTION
Add jobs to build and publish the easyto builder image on release:

- build-push-image: Builds Docker image from Dockerfile.buildimage and pushes to ghcr.io/cloudboss/easyto-builder:<version>

- build-ami: Uses easyto ami --public to create the builder AMI in us-east-1

- copy-ami: Copies the builder AMI to multiple regions in parallel (us-west-2, eu-west-1, eu-central-1, ap-northeast-1, ap-southeast-1, sa-east-1) using easyto copy-builder --public

Requires GitHub secrets:
- AWS_ROLE_ARN: IAM role ARN for OIDC authentication
- AWS_SUBNET_ID: Subnet ID for packer to use in us-east-1